### PR TITLE
Move the Poco/SharedLibrary.h header into cpp file

### DIFF
--- a/include/class_loader/class_loader_core.hpp
+++ b/include/class_loader/class_loader_core.hpp
@@ -41,11 +41,15 @@
 #include <utility>
 #include <vector>
 
-#include "Poco/SharedLibrary.h"
-
 #include "class_loader/exceptions.hpp"
 #include "class_loader/meta_object.hpp"
 #include "class_loader/visibility_control.hpp"
+
+// forward declaration
+namespace Poco
+{
+  class SharedLibrary;
+}
 
 /**
  * @note This header file is the internal implementation of the plugin system which is exposed via the ClassLoader class

--- a/src/class_loader.cpp
+++ b/src/class_loader.cpp
@@ -29,6 +29,7 @@
 
 #include "class_loader/class_loader.hpp"
 
+#include "Poco/SharedLibrary.h"
 #include <string>
 
 namespace class_loader


### PR DESCRIPTION
This is one of the PRs to remove Windows.h from ROS headers, and in turn we reduce the Windows namespace conflicts problems for many downstream packages.