### PR TITLE
Fix std::Vector link warning for exports from class_loader

### DIFF
--- a/include/class_loader/meta_object.hpp
+++ b/include/class_loader/meta_object.hpp
@@ -36,6 +36,7 @@
 #define CLASS_LOADER__META_OBJECT_HPP_
 
 #include <console_bridge/console.h>
+#include <ros/macros.h>
 #include "class_loader/visibility_control.hpp"
 
 #include <typeinfo>


### PR DESCRIPTION
Fix for https://github.com/ms-iot/ROSOnWindows/issues/30